### PR TITLE
Fix NoSQL injection with user login

### DIFF
--- a/lib/database-ops.js
+++ b/lib/database-ops.js
@@ -348,7 +348,8 @@ var findUsersByHiddenIDs = function(userIDs, callback) {
 var loginUser = function(userData, callback) {
     if (userData === undefined
         || userData.username === undefined
-        || userData.password === undefined) {
+        || userData.password === undefined
+        || typeof userData.username !== "string") {
             callback({
                 message: "Could not login user. Malformed input."
             }, null);


### PR DESCRIPTION
Report from https://lgtm.com/projects/g/Coteh/simpleimage/?mode=list&id=js%2Fsql-injection

Injecting the `username` field with something like `{"$gt": ""}` doesn't end up being very useful anyways, as the handler will only grab the first result. However, this fix will now make it impossible to do an injection at all here.