### PR TITLE
Add CSRF middleware

### DIFF
--- a/assets/js/file-upload.js
+++ b/assets/js/file-upload.js
@@ -54,7 +54,7 @@ var onFileSelected = function() {
 var onFileUploaded = function() {
     var json = JSON.parse(this.responseText);
     fileSelect.value = "";
-    if (this.status === 500) {
+    if (this.status !== 200) {
         console.error("An error ocurred: " + json.message);
         uploadPreview.style.boxShadow = "";
         uploadPreview.classList.add("error");
@@ -78,12 +78,13 @@ var uploadFile = function(file) {
     var action = form.attr("action");
     var req = new XMLHttpRequest();
     var formData = new FormData();
-
+    
     uploadPreview.classList.remove("error");
-
+    
     req.onload = onFileUploaded;
     req.onprogress = onFileProgress;
     req.open("post", action);
+    req.setRequestHeader("X-CSRF-TOKEN", csrfToken);
     formData.append("myFile", currentFile);
     req.send(formData);
 }

--- a/lib/routes/route.js
+++ b/lib/routes/route.js
@@ -8,6 +8,7 @@ const bodyParser = require("body-parser");
 const session = require("express-session");
 const validator = require("validator");
 const owasp = require("owasp-password-strength-test");
+const csurf = require("csurf");
 const logger = require("../log");
 const actionHistory = require("../action-history");
 var RedisStore, FileStore;
@@ -52,6 +53,15 @@ module.exports = function(app, router) {
             saveUninitialized: false
         }));
     }
+
+    var crsfProtection = csurf({ cookie: false });
+
+    app.use(crsfProtection);
+
+    app.use((req, res, next) => {
+        res.locals.csrfToken = req.csrfToken();
+        next();
+    });
 
     function errorHandler(err, req, res, next) {
         logger.writeError("Router has encountered an error: " + (err.stack || "No stack found for this error."));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1380,6 +1380,66 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
+    "csrf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
+      "requires": {
+        "rndm": "1.2.0",
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
+      }
+    },
+    "csurf": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
+      "integrity": "sha512-UCtehyEExKTxgiu8UHdGvHj4tnpE/Qctue03Giq5gPgMQ9cg/ciod5blZQ5a4uCEenNQjxyGuzygLdKUmee/bQ==",
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "csrf": "3.1.0",
+        "http-errors": "~1.7.3"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+        },
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+        },
+        "http-errors": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "setprototypeof": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        }
+      }
+    },
     "cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
@@ -5607,6 +5667,11 @@
         "inherits": "^2.0.1"
       }
     },
+    "rndm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
+    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -6431,6 +6496,11 @@
         }
       }
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
     "touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -6455,6 +6525,11 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+    },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "body-parser": "^1.18.2",
     "connect-redis": "^3.3.2",
     "copy-webpack-plugin": "^4.6.0",
+    "csurf": "^1.11.0",
     "dotenv": "^4.0.0",
     "ejs": "^2.5.7",
     "ejs-lint": "^0.3.0",

--- a/views/image-view.ejs
+++ b/views/image-view.ejs
@@ -52,6 +52,7 @@
                     <input type="hidden" name="userID" value="0">
                     <textarea class="comment-box" name="comment" placeholder="Add a comment"></textarea><br/>
                     <span class="button submit-button">Submit</span>
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>"></input>
                 </form><br/>
             <% } %>
             <div id="comments-container"></div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -39,6 +39,9 @@
         </div>
         <%- include("footer") %>
     </div>
+    <script>
+        var csrfToken = "<%= csrfToken %>";
+    </script>
 </body>
 
 </html>

--- a/views/login-view.ejs
+++ b/views/login-view.ejs
@@ -43,6 +43,7 @@
                         </tr>
                     </table>
                     <input type="hidden" name="redirectUrl" value="<%= fromUrl %>"></input>
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>"></input>
                     <span class="button submit-button">Submit</span>
                 </form>
                 <div id="register-from-login">

--- a/views/register-view.ejs
+++ b/views/register-view.ejs
@@ -39,6 +39,7 @@
                         </tr>
                     </table>
                     <input type="hidden" name="redirectUrl" value="<%= fromUrl %>"></input>
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>"></input>
                     <span class="button submit-button">Submit</span>
                 </form>
             </div>

--- a/views/user-menu-view.ejs
+++ b/views/user-menu-view.ejs
@@ -17,6 +17,7 @@
             <div class="nav-item nav-button nav-menu-item">
                 <form id="logout-form" method="POST" action="/logout">
                     <input type="hidden" name="redirectUrl" value="<%= fromUrl %>"></input>
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>"></input>
                 </form>
                 <span>Logout</span>
             </div>

--- a/views/user-mobile-menu-view.ejs
+++ b/views/user-mobile-menu-view.ejs
@@ -13,6 +13,7 @@
     <div class="nav-item nav-button nav-menu-item">
         <form id="logout-form" method="POST" action="/logout">
             <input type="hidden" name="redirectUrl" value="<%= fromUrl %>"></input>
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>"></input>
             <span>Logout</span>
         </form>
     </div>


### PR DESCRIPTION
See LGTM report: https://lgtm.com/projects/g/Coteh/simpleimage/alerts/?mode=list&severity=error&tag=external%2Fcwe%2Fcwe-352

Added `csurf`, implemented CSRF token passing into form requests (hidden form element for non-multipart forms, and as a request header for multipart upload form), and enabled double submit. (by enabling the `cookie` option within `csurf`)