### PR TITLE
Update Docker config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,7 @@ deploy-dev:
 
 deploy-test:
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit
+
+clean:
+	docker ps -a | grep coteh/simpleimage | cut -d' ' -f1 | xargs docker rm
+	docker volume rm simpleimage_node_modules

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,6 +11,9 @@ services:
         command: bash -c "npm run build:client & npm run start:dev"
         environment:
             - NODE_ENV=development
+    si_sessions:
+        ports:
+            - "6379:6379"
 
 volumes:
     node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,6 @@ services:
     si_sessions:
         image: redis:4.0.6
         container_name: si-sessions
-        ports:
-            - "6379:6379"
 
 volumes:
     configdb:


### PR DESCRIPTION
- Add `make clean` to Makefile to clean out `node_modules` volume (and deletes the simpleimage container), this should be used whenever installing a new module to the project and the si container complains about dependency not found. Run `make build-dev` and `make clean` before running `make deploy-dev` in this case.
- Move Redis port settings to the dev config, as Redis should never be exposed to the outside world in production.