### PR TITLE
Add more restrictions to getRedirectPath

### DIFF
--- a/lib/routes/route.js
+++ b/lib/routes/route.js
@@ -25,6 +25,12 @@ var upload = multer({
     limits: {fileSize: 500000000}
 });
 
+const validPathRedirects = ["/"];
+
+const resolveValidPathRedirect = function(rediretPath) {
+    return validPathRedirects.some((path) => rediretPath === path) ? rediretPath : "/";
+};
+
 module.exports = function(app, router) {
     app.use(bodyParser.json());
     app.use(bodyParser.urlencoded({
@@ -843,7 +849,7 @@ module.exports = function(app, router) {
                     message: "User registered."
                 });
             } else {
-                res.redirect(util.getRedirectPath(req.body.redirectUrl));
+                res.redirect(resolveValidPathRedirect(util.getRedirectPath(req.body.redirectUrl)));
             }
         });
     });
@@ -884,14 +890,14 @@ module.exports = function(app, router) {
                     message: result.message
                 });
             } else {
-                res.redirect(util.getRedirectPath(req.body.redirectUrl));
+                res.redirect(resolveValidPathRedirect(util.getRedirectPath(req.body.redirectUrl)));
             }
         });
     });
 
     router.post("/logout", limiter, function (req, res, next) {
         req.session.destroy();
-        res.redirect(util.getRedirectPath(req.body.redirectUrl));
+        res.redirect(resolveValidPathRedirect(util.getRedirectPath(req.body.redirectUrl)));
     });
 
     router.delete("/images/:id", limiter, function (req, res, next) {

--- a/lib/routes/route.js
+++ b/lib/routes/route.js
@@ -280,8 +280,7 @@ module.exports = function(app, router) {
             res.status(200);
             res.append("Cache-Control", "private, max-age=0, must-revalidate");
             res.render("index", {
-                user: sessionObj.user,
-                fromUrl: req.url
+                user: sessionObj.user
             });
         });
     });
@@ -350,8 +349,7 @@ module.exports = function(app, router) {
                         imageSrc: id + "." + util.mimeTypeToExt(imageEntry[0].mimetype),
                         uploadedDate: imageEntry[0].uploadeddate || "Unknown Date",
                         author: imageEntry[0].username,
-                        user: sessionObj.user,
-                        fromUrl: req.url
+                        user: sessionObj.user
                     });
                     logger.writeLog("Served image " + imageEntry[0].id + " via image page", logger.SeverityLevel.INFO);
                 }
@@ -396,8 +394,7 @@ module.exports = function(app, router) {
                     res.append("Cache-Control", "private, max-age=0, must-revalidate");
                     res.render("user-view", {
                         user,
-                        sessionUser: sessionObj.user,
-                        fromUrl: req.url
+                        sessionUser: sessionObj.user
                     });
                 }
                 logger.writeLog("Served user page of user " + user.username + ".", logger.SeverityLevel.INFO);
@@ -527,7 +524,6 @@ module.exports = function(app, router) {
 
     router.get("/register", function(req, res, next) {
         res.render("register-view", {
-            fromUrl: req.query.fromUrl || "home",
             responseType: req.query.responseType || "html"
         }, function (err, html) {
             if (err) {
@@ -549,7 +545,6 @@ module.exports = function(app, router) {
 
     router.get("/login", function (req, res, next) {
         res.render("login-view", {
-            fromUrl: req.query.fromUrl || "home",
             responseType: req.query.responseType || "html"
         }, function(err, html) {
             if (err) {
@@ -843,7 +838,7 @@ module.exports = function(app, router) {
                     message: "User registered."
                 });
             } else {
-                res.redirect(util.getRedirectPath(req.body.redirectUrl));
+                res.redirect(util.getRedirectPath(req.header("Referrer")));
             }
         });
     });
@@ -884,14 +879,14 @@ module.exports = function(app, router) {
                     message: result.message
                 });
             } else {
-                res.redirect(util.getRedirectPath(req.body.redirectUrl));
+                res.redirect(util.getRedirectPath(req.header("Referrer")));
             }
         });
     });
 
     router.post("/logout", limiter, function (req, res, next) {
         req.session.destroy();
-        res.redirect(util.getRedirectPath(req.body.redirectUrl));
+        res.redirect(util.getRedirectPath(req.header("Referrer")));
     });
 
     router.delete("/images/:id", limiter, function (req, res, next) {

--- a/lib/routes/route.js
+++ b/lib/routes/route.js
@@ -25,12 +25,6 @@ var upload = multer({
     limits: {fileSize: 500000000}
 });
 
-const validPathRedirects = ["/"];
-
-const resolveValidPathRedirect = function(rediretPath) {
-    return validPathRedirects.some((path) => rediretPath === path) ? rediretPath : "/";
-};
-
 module.exports = function(app, router) {
     app.use(bodyParser.json());
     app.use(bodyParser.urlencoded({
@@ -849,7 +843,7 @@ module.exports = function(app, router) {
                     message: "User registered."
                 });
             } else {
-                res.redirect(resolveValidPathRedirect(util.getRedirectPath(req.body.redirectUrl)));
+                res.redirect(util.getRedirectPath(req.body.redirectUrl));
             }
         });
     });
@@ -890,14 +884,14 @@ module.exports = function(app, router) {
                     message: result.message
                 });
             } else {
-                res.redirect(resolveValidPathRedirect(util.getRedirectPath(req.body.redirectUrl)));
+                res.redirect(util.getRedirectPath(req.body.redirectUrl));
             }
         });
     });
 
     router.post("/logout", limiter, function (req, res, next) {
         req.session.destroy();
-        res.redirect(resolveValidPathRedirect(util.getRedirectPath(req.body.redirectUrl)));
+        res.redirect(util.getRedirectPath(req.body.redirectUrl));
     });
 
     router.delete("/images/:id", limiter, function (req, res, next) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -91,12 +91,14 @@ module.exports.getRedirectPath = function(redirectUrl) {
         return "/";
     }
     var urlObj = url.parse(redirectUrl);
-    switch (urlObj.pathname) {
-        case "home":
-            return "/";
-        default:
-            return urlObj.pathname;
+    // check for bad stuff
+    if (urlObj.protocol === "javascript:"
+        || urlObj.protocol === "data:"
+        || urlObj.pathname.indexOf("//") == 0
+        || urlObj.pathname.search("%0D|%0A") >= 0) {
+        return "/";
     }
+    return urlObj.pathname;
 };
 
 if (process.env.NODE_ENV === "test") {

--- a/lib/util.js
+++ b/lib/util.js
@@ -91,14 +91,11 @@ module.exports.getRedirectPath = function(redirectUrl) {
         return "/";
     }
     var urlObj = url.parse(redirectUrl);
-    if (urlObj.host !== null) {
-        return "/";
-    }
     switch (urlObj.pathname) {
         case "home":
             return "/";
         default:
-            return urlObj.path;
+            return urlObj.pathname;
     }
 };
 

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -129,9 +129,6 @@ describe("util", function() {
                 var myURL = "https://www.simpleimage.com/images/test";
                 assert.strictEqual(util.getRedirectPath(myURL), "/images/test");
             });
-            it("should return root path string given 'home' string as url", function() {
-                assert.strictEqual(util.getRedirectPath("home"), "/");
-            });
             it("should return root path string given undefined as url", function () {
                 assert.strictEqual(util.getRedirectPath(undefined), "/");
             });
@@ -148,6 +145,18 @@ describe("util", function() {
             });
             it("should return just the relative path if malicious URL is provided", function() {
                 assert.strictEqual(util.getRedirectPath("http://evilsite.com/foo/bar?somequery=value"), "/foo/bar");
+            });
+            it("should block relative paths with two slashes in front", function() {
+                assert.strictEqual(util.getRedirectPath("//google.com"), "/");
+            });
+            it("should block javascript: protocol URLs", function() {
+                assert.strictEqual(util.getRedirectPath("javascript:alert(1)"), "/");
+            });
+            it("should block data: protocol URLs", function() {
+                assert.strictEqual(util.getRedirectPath("data:text/html,<script>alert(document.domain)</script>"), "/");
+            });
+            it("should block URLs with CRLF characters", function() {
+                assert.strictEqual(util.getRedirectPath("/index\r\nsomething"), "/");
             });
         });
     });

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -135,6 +135,20 @@ describe("util", function() {
             it("should return root path string given undefined as url", function () {
                 assert.strictEqual(util.getRedirectPath(undefined), "/");
             });
+            it("should return root slash if root slash is given", function() {
+                var path = "/";
+                assert.strictEqual(util.getRedirectPath(path), path);
+            });
+            it("should return the same string if relative path already given", function() {
+                var path = "/my_path";
+                assert.strictEqual(util.getRedirectPath(path), path);
+            });
+            it("should strip out queries from the URL", function() {
+                assert.strictEqual(util.getRedirectPath("/index.html?query=something"), "/index.html");
+            });
+            it("should return just the relative path if malicious URL is provided", function() {
+                assert.strictEqual(util.getRedirectPath("http://evilsite.com/foo/bar?somequery=value"), "/foo/bar");
+            });
         });
     });
 });

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -146,7 +146,7 @@ describe("util", function() {
             it("should return just the relative path if malicious URL is provided", function() {
                 assert.strictEqual(util.getRedirectPath("http://evilsite.com/foo/bar?somequery=value"), "/foo/bar");
             });
-            it("should block relative paths with two slashes in front", function() {
+            it("should block relative paths with two (or more) slashes in front", function() {
                 assert.strictEqual(util.getRedirectPath("//google.com"), "/");
             });
             it("should block javascript: protocol URLs", function() {

--- a/views/image-view.ejs
+++ b/views/image-view.ejs
@@ -23,7 +23,7 @@
 <body>
     <div id="overlay-backdrop">
     </div>
-    <%- include("top-nav-view", {user,fromUrl}) %>
+    <%- include("top-nav-view", {user}) %>
     <div id="contents" class="page-contents">
         <div id="notification-overlay-container">
         </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -16,7 +16,7 @@
 <body>
     <div id="overlay-backdrop">
     </div>
-    <%- include("top-nav-view", {user,fromUrl}) %>
+    <%- include("top-nav-view", {user}) %>
     <div id="contents">
         <div id="notification-overlay-container">
         </div>

--- a/views/login-view.ejs
+++ b/views/login-view.ejs
@@ -42,7 +42,6 @@
                             </td>
                         </tr>
                     </table>
-                    <input type="hidden" name="redirectUrl" value="<%= fromUrl %>"></input>
                     <input type="hidden" name="_csrf" value="<%= csrfToken %>"></input>
                     <span class="button submit-button">Submit</span>
                 </form>

--- a/views/register-view.ejs
+++ b/views/register-view.ejs
@@ -38,7 +38,6 @@
                             <td><input type="text" name="email"></input></td>
                         </tr>
                     </table>
-                    <input type="hidden" name="redirectUrl" value="<%= fromUrl %>"></input>
                     <input type="hidden" name="_csrf" value="<%= csrfToken %>"></input>
                     <span class="button submit-button">Submit</span>
                 </form>

--- a/views/top-nav-view.ejs
+++ b/views/top-nav-view.ejs
@@ -7,7 +7,7 @@
             <% if (user === undefined) { %>
             <%- include("guest-menu-view") %>
             <% } else { %>
-            <%- include("user-menu-view",{user,fromUrl}) %>
+            <%- include("user-menu-view",{user}) %>
             <% } %>
             <div id="mobile-menu-button" class="nav-item user nav-drawer nav-right-1">
                 <span class="collecticon collecticon-hamburger-menu head-icon"></span>
@@ -18,7 +18,7 @@
         <% if (user === undefined) { %>
         <%- include("guest-mobile-menu-view") %>
         <% } else { %>
-        <%- include("user-mobile-menu-view",{user,fromUrl}) %>
+        <%- include("user-mobile-menu-view",{user}) %>
         <% } %>
     </div>
 </div>

--- a/views/user-menu-view.ejs
+++ b/views/user-menu-view.ejs
@@ -16,7 +16,6 @@
         <a href="#" class="noselect" onclick="document.getElementById('logout-form').submit();">
             <div class="nav-item nav-button nav-menu-item">
                 <form id="logout-form" method="POST" action="/logout">
-                    <input type="hidden" name="redirectUrl" value="<%= fromUrl %>"></input>
                     <input type="hidden" name="_csrf" value="<%= csrfToken %>"></input>
                 </form>
                 <span>Logout</span>

--- a/views/user-mobile-menu-view.ejs
+++ b/views/user-mobile-menu-view.ejs
@@ -12,7 +12,6 @@
 <a href="#" class="noselect" onclick="document.getElementById('logout-form').submit();">
     <div class="nav-item nav-button nav-menu-item">
         <form id="logout-form" method="POST" action="/logout">
-            <input type="hidden" name="redirectUrl" value="<%= fromUrl %>"></input>
             <input type="hidden" name="_csrf" value="<%= csrfToken %>"></input>
             <span>Logout</span>
         </form>

--- a/views/user-view.ejs
+++ b/views/user-view.ejs
@@ -26,7 +26,7 @@
 <body>
     <div id="overlay-backdrop">
     </div>
-    <%- include("top-nav-view", {user:sessionUser,fromUrl}) %>
+    <%- include("top-nav-view", {user:sessionUser}) %>
     <div id="contents" class="page-contents">
         <div id="notification-overlay-container">
         </div>


### PR DESCRIPTION
https://owasp.org/www-community/attacks/Code_Injection

Code injections to vulnerable server routes are technically possible using query strings. I don't believe any of the routes within simpleimage can be exploited using this method. However, none of my redirect urls make use of query strings so they can be omitted.

Edit: Restrict redirect URLs further by only allowing redirects from a set list of redirects.