### PR TITLE
Remove fromUrl from settings-view endpoint

### DIFF
--- a/lib/routes/route.js
+++ b/lib/routes/route.js
@@ -420,7 +420,6 @@ module.exports = function(app, router) {
 
             res.render("settings-view", {
                 sessionUser: sessionObj.user,
-                fromUrl: req.url
             });
         });
     });

--- a/views/settings-view.ejs
+++ b/views/settings-view.ejs
@@ -53,7 +53,7 @@
 <body>
     <div id="overlay-backdrop">
     </div>
-    <%- include("top-nav-view", {user:sessionUser,fromUrl}) %>
+    <%- include("top-nav-view", {user:sessionUser}) %>
     <div id="contents" class="page-contents">
         <div id="notification-overlay-container">
         </div>


### PR DESCRIPTION
`fromUrl` was removed in https://github.com/Coteh/simpleimage/commit/ac96c9fa00fd7daddf741570114f7d98e7f7354c but still existed in `settings` route. Removed it.

Fixes #135.