### PR TITLE
Add secure attribute to cookie

### DIFF
--- a/lib/routes/route.js
+++ b/lib/routes/route.js
@@ -33,17 +33,23 @@ module.exports = function(app, router) {
         extended: true
     }));
 
-    app.set("trust proxy", true);
-
     if (process.env.NODE_ENV === "production"
-        || process.env.NODE_ENV === "development") {
+    || process.env.NODE_ENV === "development") {
+        let cookiePref = undefined;
+        if (process.env.NODE_ENV === "production") {
+            app.set("trust proxy", 1);
+            cookiePref = {
+                secure: true,
+            }
+        }
         app.use(session({
             store: new RedisStore({
                 url: process.env.REDIS_URL
             }),
             secret: process.env.SESSION_SECRET,
             resave: false,
-            saveUninitialized: false
+            saveUninitialized: false,
+            cookie: cookiePref,
         }));
     } else {
         // If running on local machine, use file store sessions instead

--- a/lib/routes/route.js
+++ b/lib/routes/route.js
@@ -32,16 +32,10 @@ module.exports = function(app, router) {
     app.use(bodyParser.urlencoded({
         extended: true
     }));
+    app.set("trust proxy", 1);
 
     if (process.env.NODE_ENV === "production"
     || process.env.NODE_ENV === "development") {
-        let cookiePref = undefined;
-        if (process.env.NODE_ENV === "production") {
-            app.set("trust proxy", 1);
-            cookiePref = {
-                secure: true,
-            }
-        }
         app.use(session({
             store: new RedisStore({
                 url: process.env.REDIS_URL
@@ -49,7 +43,9 @@ module.exports = function(app, router) {
             secret: process.env.SESSION_SECRET,
             resave: false,
             saveUninitialized: false,
-            cookie: cookiePref,
+            cookie: {
+                secure: (process.env.NODE_ENV === "production"),
+            },
         }));
     } else {
         // If running on local machine, use file store sessions instead


### PR DESCRIPTION
Addressing this issue:

> Cookie “connect.sid” will be soon rejected because it has the “sameSite” attribute set to “none” or an invalid value, without the “secure” attribute. To know more about the “sameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite

Keeping in draft until I test it somehow locally. (perhaps by setting up local https server #182 or something else)