### PR TITLE
Change Upload icon

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -33,7 +33,7 @@
                     <span class="collecticons collecticons-picture head-icon"></span>
                 </div>
                 <div class="button" id="upload-button">
-                    <span class="collecticons collecticons-upload head-icon"></span>
+                    <span class="collecticons collecticons-upload-2 head-icon"></span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Updated Upload icon from "upload" icon in Collecticons library to "upload-2". IMO this alternative upload icon looks simpler and more sleek.

http://collecticons.io/

![image](https://user-images.githubusercontent.com/3276350/120897872-49758f80-c5f6-11eb-9820-bdbfaf8caab8.png)
