### PR TITLE
Ensure a session secret is provided in production environment.

### DIFF
--- a/lib/routes/route.js
+++ b/lib/routes/route.js
@@ -38,7 +38,7 @@ module.exports = function(app, router) {
     if (!process.env.SESSION_SECRET && process.env.NODE_ENV !== "development") {
         throw new Error("Must provide a secret for sessions");
     }
-    const sessionSecret = process.env.SESSION_SECRET || "mysecret";
+    const sessionSecret = process.env.SESSION_SECRET;
 
     if (process.env.NODE_ENV === "production"
     || process.env.NODE_ENV === "development") {

--- a/lib/routes/route.js
+++ b/lib/routes/route.js
@@ -35,13 +35,18 @@ module.exports = function(app, router) {
     }));
     app.set("trust proxy", 1);
 
+    if (!process.env.SESSION_SECRET && process.env.NODE_ENV !== "development") {
+        throw new Error("Must provide a secret for sessions");
+    }
+    const sessionSecret = process.env.SESSION_SECRET || "mysecret";
+
     if (process.env.NODE_ENV === "production"
     || process.env.NODE_ENV === "development") {
         app.use(session({
             store: new RedisStore({
                 url: process.env.REDIS_URL
             }),
-            secret: process.env.SESSION_SECRET,
+            secret: sessionSecret,
             resave: false,
             saveUninitialized: false,
             cookie: {
@@ -55,7 +60,7 @@ module.exports = function(app, router) {
                 path: "./sessions",
                 ttl: 21600
             }) : undefined,
-            secret: process.env.SESSION_SECRET,
+            secret: sessionSecret,
             resave: true,
             saveUninitialized: false
         }));


### PR DESCRIPTION
Closes #70.

Seems like the only way to easily catch this error while server is running is by checking the string in error message. This is because the error is thrown by express-session during the route handling process, as seen [here](https://github.com/expressjs/session/blob/a8641429502fcc076c4b2dcbd6b2320891c1650c/index.js#L200). I prefer not to handle the error in this manner unless absolutely necessary, especially because the string can change any time in a future update of express-session.

Instead, I think it would actually make more sense if the server did not run at all if session secret were not provided. And in this PR, I have done just that. When app is set in production mode, it will throw an error and exit if secret is not provided. This avoids having to deal with the message string itself and also ensures that the error is handled before user can see it.