### PR TITLE
Replace html encoding function with html-entities library

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,28 +1,6 @@
 var mimeTypes = require("mime-types");
 var url = require("url");
-
-var encodeHTML = function (text) {
-    if (text === undefined) {
-        return undefined;
-    }
-    return text.split("").map(function (element) {
-        switch (element) {
-            case "<":
-                return "&lt;";
-            case ">":
-                return "&gt;";
-            case "&":
-                return "&amp;";
-            case "\"":
-                return "&quot;";
-            case "'":
-                return "&#39;";
-        }
-        return element;
-    }).reduce(function (accum, curr) {
-        return accum + curr;
-    }, "");
-};
+const { encode } = require("html-entities");
 
 module.exports.getIDFromParam = function(idStr) {
     return idStr;
@@ -68,7 +46,7 @@ module.exports.sanitizeText = function(text) {
 };
 
 module.exports.escapeOutput = function(text) {
-    return encodeHTML(text);
+    return encode(text);
 };
 
 module.exports.getRedirectPath = function(redirectUrl) {
@@ -110,6 +88,5 @@ module.exports.constructBase64ImageArray = function(imgArr) {
 };
 
 if (process.env.NODE_ENV === "test") {
-    module.exports.encodeHTML = encodeHTML;
     module.exports.convertImageBinaryToBase64 = convertImageBinaryToBase64;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "express-rate-limit": "^5.0.0",
         "express-session": "^1.15.6",
         "file-type": "^7.4.0",
+        "html-entities": "^2.3.2",
         "mime-types": "^2.1.27",
         "mongo-sanitize": "^1.1.0",
         "mongodb": "^2.2.9",
@@ -5361,6 +5362,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+      "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ=="
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -17484,6 +17490,11 @@
       "requires": {
         "parse-passwd": "^1.0.0"
       }
+    },
+    "html-entities": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+      "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ=="
     },
     "html-escaper": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express-rate-limit": "^5.0.0",
     "express-session": "^1.15.6",
     "file-type": "^7.4.0",
+    "html-entities": "^2.3.2",
     "mime-types": "^2.1.27",
     "mongo-sanitize": "^1.1.0",
     "mongodb": "^2.2.9",

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -39,20 +39,6 @@ describe("util", function() {
         });
     });
 
-    describe("internal functions", function() {
-        describe("encodeHTML", function () {
-            it("should encode '<', '>', and '&' characters", function () {
-                assert.strictEqual(util.encodeHTML("<>&"), "&lt;&gt;&amp;");
-            });
-            it("should encode single quote and double quote characters", function () {
-                assert.strictEqual(util.encodeHTML("'\""), "&#39;&quot;");
-            });
-            it("should return undefined if undefined is passed in as the string", function () {
-                assert.strictEqual(util.encodeHTML(undefined), undefined);
-            });
-        });
-    });
-
     describe("external functions", function() {
         describe("extToMimeType", function() {
             it("should return a MIME type string given an extension string", function() {
@@ -120,13 +106,13 @@ describe("util", function() {
         });
         describe("escapeOutput", function () {
             it("should escape text with HTML special characters", function () {
-                assert.strictEqual(util.escapeOutput("<>&\"'"), "&lt;&gt;&amp;&quot;&#39;");
+                assert.strictEqual(util.escapeOutput("<>&\"'"), "&lt;&gt;&amp;&quot;&apos;");
             });
             it("should return empty string if empty string passed in", function () {
                 assert.strictEqual(util.escapeOutput(""), "");
             });
-            it("should return undefined if undefined passed in", function () {
-                assert.strictEqual(util.escapeOutput(undefined), undefined);
+            it("should return empty string if undefined passed in", function () {
+                assert.strictEqual(util.escapeOutput(undefined), "");
             });
         });
         describe("getRedirectPath", function () {


### PR DESCRIPTION
Closes #18 

- Also change apostrophe encode in tests since html-entities library uses `&apos;` instead of `&#39;`
- Also change undefined test case because html-entities returns empty string if undefined is passed in