### PR TITLE
Allow session secret to have a default value in dev and in test

### DIFF
--- a/lib/routes/route.js
+++ b/lib/routes/route.js
@@ -35,10 +35,10 @@ module.exports = function(app, router) {
     }));
     app.set("trust proxy", 1);
 
-    if (!process.env.SESSION_SECRET && process.env.NODE_ENV !== "development") {
+    if (!process.env.SESSION_SECRET && process.env.NODE_ENV === "production") {
         throw new Error("Must provide a secret for sessions");
     }
-    const sessionSecret = process.env.SESSION_SECRET;
+    const sessionSecret = process.env.SESSION_SECRET || "mysecret";
 
     if (process.env.NODE_ENV === "production"
     || process.env.NODE_ENV === "development") {


### PR DESCRIPTION
This would allow forked projects to run CI tests without requiring session secret. It seems like session secret can only be passed to forked projects in CircleCI if all secrets (env vars, etc.) are passed down, so this is a better alternative for now IMO.