### PR TITLE
Turn on dryRun mode for Sentry webpack plugin when in development mode.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,7 @@ module.exports = {
             release: "simpleimage@" + process.env.npm_package_version,
             // rewrites "~/public/assets/js" prefix into "~/assets/js" so Sentry can detect the source maps
             urlPrefix: "~/assets/js",
+            dryRun: process.env.NODE_ENV === "development",
 
             // webpack-specific configuration
             include: ["./public/assets/js"],


### PR DESCRIPTION
So that error does not appear when developing without a Sentry account.

Error looked something like this:
```
si-app         | ERROR in Sentry CLI Plugin: Command failed: /usr/src/simpleimage/node_modules/@sentry/cli/sentry-cli releases new simpleimage@1.3.1
si-app         | error: An organization slug is required (provide with --org)
si-app         |
si-app         | Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.
si-app         | Please attach the full debug log to all bug reports.
```

Now it just emits information about the source map upload and current settings for Sentry plugin, but does not actually upload the source maps. (hence the dry run)

```
si-app         | [Sentry Webpack Plugin] Creating new release:
si-app         |  'simpleimage@1.3.1'
si-app         | [Sentry Webpack Plugin] Calling upload-sourcemaps with:
si-app         |  {
si-app         |   finalize: true,
si-app         |   rewrite: true,
si-app         |   authToken: undefined,
si-app         |   org: undefined,
si-app         |   project: 'simpleimage',
si-app         |   release: 'simpleimage@1.3.1',
si-app         |   urlPrefix: '~/assets/js',
si-app         |   dryRun: true,
si-app         |   include: [ './public/assets/js' ],
si-app         |   ignore: [ 'node_modules', 'webpack.config.js' ]
si-app         | }
si-app         | [Sentry Webpack Plugin] Finalizing release:
si-app         |  'simpleimage@1.3.1'
si-app         | Hash: 5d8fef3f4e7296230f71
si-app         | Version: webpack 4.44.1
si-app         | Time: 7508ms
si-app         | Built at: 09/08/2021 3:33:05 AM
```
