### PR TITLE
Remove EXIF rotation from preview image and remove EXIF dependencies from frontend

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -26,7 +26,7 @@ input[type="file"] {
     max-height: 200px;
     position: relative;
     opacity: 0;
-    transition: opacity 0.2s ease;
+    transition: opacity 0.5s ease;
 }
 
 #contents {

--- a/assets/js/file-upload.js
+++ b/assets/js/file-upload.js
@@ -3,56 +3,42 @@ var fileSelect;
 var currentFile;
 var isUserLoggedIn = false;
 
-var onFileSelected = function() {
-    var files = fileSelect.files;
-
+const showUploadPreview = async function(file) {
     while (uploadPreview.firstChild) {
         uploadPreview.removeChild(uploadPreview.firstChild);
     }
     uploadPreview.className = "";
-
-    for (var i = 0; i < files.length; i++) {
-        var image = document.createElement("img");
-        var exifRemoved = false;
-        var previewLoadHandler = (function (file) {
-            return function (evt) {
-                if (exifRemoved) {
-                    image.style.opacity = 1;
-                } else {
-                    image.style.top = (-this.height + 15) + "px";
-                    if (file.type !== "image/jpeg") {
-                        image.style.opacity = 1;
-                        return;
-                    }
-                    autoRotateImage(evt.target);
-                    evt.target.src = stripEXIF(evt.target);
-                    exifRemoved = true;
-                }
-            }
-        })(files[i]);
-        // This load event listener will fire twice
-        // First time when local preview image is initially loaded
-        // Second time after the image element's src property
-        // is changed to be the modified version without orientation
-        image.addEventListener("load", previewLoadHandler);
-        var reader = new FileReader();
-        reader.readAsDataURL(files[i]);
-        reader.onloadend = function() {
-            var dataURL = reader.result;
-            image.src = dataURL;
-        };
-        // var blobURL = window.URL.createObjectURL(files[i]);
-        // image.src = blobURL;
-        image.className = "image-preview";
-        uploadPreview.appendChild(image);
-        uploadPreview.className = "selected";
-        currentFile = files[i];
-    }
-
     uploadPreview.style.boxShadow = "";
+
+    const imageElem = document.createElement("img");
+    imageElem.className = "image-preview";
+    uploadPreview.appendChild(imageElem);
+
+    const imageData = await readImage(file);
+    await setImageSrc(imageElem, imageData);
+    
+    imageElem.style.transform = "translateY(-90%)";
+    imageElem.style.opacity = 1;
+
+    uploadPreview.className = "selected";
 }
 
-var onFileUploaded = function() {
+const onFileSelected = function() {
+    const files = fileSelect.files;
+
+    if (files.length === 0) {
+        return showNotification("No files selected", {
+            error: true,
+            close: true,
+        });
+    }
+
+    currentFile = files[0];
+
+    showUploadPreview(files[0]);
+}
+
+const onFileUploaded = function() {
     let json;
     try {
         json = JSON.parse(this.responseText);
@@ -73,14 +59,14 @@ var onFileUploaded = function() {
     window.location.href = window.location.origin + "/images/" + json.id;
 }
 
-var onFileProgress = function(progressEvent) {
+const onFileProgress = function(progressEvent) {
     if (progressEvent.lengthComputable) {
         var shadowValue = Math.floor((progressEvent.loaded / progressEvent.total) * 10);
         uploadPreview.style.boxShadow = "0px 3px 25px " + shadowValue.toString() + "px #ff0";
     }
 }
 
-var uploadFile = function(file) {
+const uploadFile = function(file) {
     var form = $("form[id='upload']");
     var action = form.attr("action");
     var req = new XMLHttpRequest();
@@ -115,7 +101,7 @@ $(document).ready(function() {
     });
 });
 
-var checkUserLogin = function (callback) {
+const checkUserLogin = function (callback) {
     var req = new XMLHttpRequest();
     req.open("get", "/user");
     req.send();
@@ -124,7 +110,7 @@ var checkUserLogin = function (callback) {
     }
 }
 
-var performLoggedInAction = function(evt, callback) {
+const performLoggedInAction = function(evt, callback) {
     if(isLoginRequired === "true" && !isUserLoggedIn) {
         evt.preventDefault();
         checkUserLogin(function (status) {

--- a/assets/js/image-util-frontend.js
+++ b/assets/js/image-util-frontend.js
@@ -1,66 +1,20 @@
-import EXIF from "exif-js";
-import piexifjs from "piexifjs";
-
-// Strips EXIF from local preview image
-// that is displayed before uploading.
-window.stripEXIF = function(img) {
-    return piexifjs.remove(img.src);
-};
-
-window.getTranslationValue = function(orientation) {
-    var ua = $("#upload-area");
-    var ip = $(".image-preview");
-    var uploadAreaPos = ua.position().top + ua.height() / 2;
-    var imagePreviewPos = ip.position().top + ip.height();
-    var translation = uploadAreaPos - imagePreviewPos;
-    if (orientation >= 7) {
-        return -translation;
-    } else {
-        return translation;
-    }
-};
-
-window.autoRotateImage = function(img) {
-    EXIF.getData(img, function () {
-        var orientation = EXIF.getTag(this, "Orientation");
-        var cssTransformations = {
-            rotate: "",
-            scale: "",
-            translate: ""
+// Read image using FileReader and return as promise
+window.readImage = function(file) {
+    return new Promise(function(resolve, reject) {
+        var reader = new FileReader();
+        reader.onload = function (e) {
+            resolve(e.target.result);
         };
+        reader.readAsDataURL(file);
+    });
+}
 
-        switch (orientation) {
-            case 1: // do nothing
-                break;
-            case 2:
-                cssTransformations.scale = "scaleX(-1)";
-                break;
-            case 3:
-                cssTransformations.scale = "scale(-1)";
-                break;
-            case 4:
-                cssTransformations.scale = "scaleY(-1)";
-                break;
-            case 5:
-                cssTransformations.rotate = "rotate(-270deg)";
-                cssTransformations.scale = "scaleY(-1)";
-                break;
-            case 6:
-                cssTransformations.rotate = "rotate(90deg)";
-                break;
-            case 7:
-                cssTransformations.rotate = "rotate(90deg)";
-                cssTransformations.scale = "scaleX(-1)";
-                break;
-            case 8:
-                cssTransformations.rotate = "rotate(-90deg)";
-                break;
-        }
-
-        var cssTransformationString = cssTransformations.rotate + " " + cssTransformations.scale;
-        img.style.transform = cssTransformationString;
-        // Get the translation value after rotating image
-        cssTransformations.translate = "translate" + ((orientation >= 5) ? "X" : "Y") + "(" + getTranslationValue(orientation) + "px)";
-        img.style.transform = cssTransformationString + " " + cssTransformations.translate;
+// Set image src using promise and resolve when it loads
+window.setImageSrc = function(img, src) {
+    return new Promise(function(resolve, reject) {
+        img.onload = function() {
+            resolve();
+        };
+        img.src = src;
     });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -388,7 +388,6 @@
       "version": "1.68.0",
       "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.68.0.tgz",
       "integrity": "sha512-zc7+cxKDqpHLREGJKRH6KwE8fZW8bnczg3OLibJ0czleXoWPdAuOK1Xm1BTMcOnaXfg3VKAh0rI7S1PTdj+SrQ==",
-      "dev": true,
       "requires": {
         "https-proxy-agent": "^5.0.0",
         "mkdirp": "^0.5.5",
@@ -460,7 +459,6 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-1.17.1.tgz",
       "integrity": "sha512-L47a0hxano4a+9jbvQSBzHCT1Ph8fYAvGGUvFg8qc69yXS9si5lXRNIH/pavN6mqJjhQjAcEsEp+vxgvT4xZDQ==",
-      "dev": true,
       "requires": {
         "@sentry/cli": "^1.68.0"
       }
@@ -842,7 +840,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
       "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
-      "dev": true,
       "requires": {
         "debug": "4"
       },
@@ -851,7 +848,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -859,8 +855,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -3283,11 +3278,6 @@
         "debug": "^2.2"
       }
     },
-    "exif-js": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/exif-js/-/exif-js-2.3.0.tgz",
-      "integrity": "sha1-nRCBm/Vx+HOBPnZAJBJVq5zhqBQ="
-    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -4451,7 +4441,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -4461,7 +4450,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -4469,8 +4457,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -6402,8 +6389,7 @@
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -7912,8 +7898,7 @@
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -7950,8 +7935,7 @@
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "proxyquire": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "ejs": "^2.5.7",
     "ejs-lint": "^1.2.1",
     "exif": "^0.6.0",
-    "exif-js": "^2.3.0",
     "express": "^4.14.0",
     "express-rate-limit": "^5.0.0",
     "express-session": "^1.15.6",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ if (!process.env.SENTRY_ORG) {
 }
 
 module.exports = {
-    mode: "production",
+    mode: process.env.WEBPACK_MODE || "production",
     devtool: "source-map",
     entry: {
         'assets/js/home.bundle': ['./assets/js/main.js', './assets/js/file-upload.js', './assets/js/util-frontend.js', './assets/js/image-util-frontend.js'],
@@ -41,7 +41,7 @@ module.exports = {
                 },
             ],
         }),
-        new SentryWebpackPlugin({
+        process.env.NODE_ENV !== "development" ? new SentryWebpackPlugin({
             // sentry-cli configuration
             authToken: process.env.SENTRY_AUTH_TOKEN,
             org: process.env.SENTRY_ORG,
@@ -49,16 +49,16 @@ module.exports = {
             release: "simpleimage@" + process.env.npm_package_version,
             // rewrites "~/public/assets/js" prefix into "~/assets/js" so Sentry can detect the source maps
             urlPrefix: "~/assets/js",
-            dryRun: !process.env.SENTRY_ORG || process.env.NODE_ENV === "development",
+            dryRun: !process.env.SENTRY_ORG,
 
             // webpack-specific configuration
             include: ["./public/assets/js"],
             ignore: ["node_modules", "webpack.config.js"],
-        }),
+        }) : null,
         new DefinePlugin({
             "SI_VERSION": JSON.stringify(process.env.npm_package_version),
             "NODE_ENV": JSON.stringify(process.env.NODE_ENV) || "development",
             "SENTRY_DSN": JSON.stringify(process.env.SENTRY_DSN),
         }),
-    ],
+    ].filter(plugin => !!plugin),
 };


### PR DESCRIPTION
Closes #17. 

Notes:
- [Modern browsers appear to support EXIF orientation now](https://caniuse.com/?search=image-orientation), which means that rotating the image preview is not required anymore. (images are still rotated server-side, however)
- Bundle size has been reduced by ~26% (from 169.11 kB to 125.75 kB).
- Took [GitHub Copilot](https://copilot.github.com/) for a test drive while working on this issue - it was able to write out two new image util functions on my behalf (`readImage` and `setImageSrc`) and also provided the suggestion to use `!!plugin` for the plugin filter in `webpack.config.js`.

Other Changes:
- Clean up onFileSelected function and split off the code related to upload preview element
- Remove Sentry webpack plugin when in development mode to speed up rebuild time
- Slightly increase opacity transition for image preview
- Change translation value for image preview to be based on percentages, which has slightly moved it down
- Add util methods for setting image src and reading image data, and remove all other image util frontend functions