### PR TITLE
Add the ability to set file size limit for images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
             - "node_modules"
       - run:
           name: Create large image test asset
-          command: ./generate_large_image.sh
+          command: ./test/scripts/generate_large_image.sh
       - run:
           name: Run tests
           command: npm run test:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   run-integ-tests:
     docker:
-      - image: coteh/si-test-deps:0.0.2
+      - image: coteh/si-test-deps:0.0.3
     steps:
       - checkout
       - restore_cache:
@@ -18,6 +18,9 @@ jobs:
           paths:
             - "$HOME/.npm"
             - "node_modules"
+      - run:
+          name: Create large image test asset
+          command: ./generate_large_image.sh
       - run:
           name: Run tests
           command: npm run test:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
           command: npm run test:ci
           environment:
               MOCHA_FILE: ./junit/simpleimage/test-results.xml
+              FILE_SIZE_LIMIT: "5000000"
       - codecov/upload:
           file: ./coverage/lcov.info
       - store_artifacts:

--- a/.circleci/images/primary/Dockerfile
+++ b/.circleci/images/primary/Dockerfile
@@ -3,4 +3,5 @@ FROM node:14
 RUN apt-get update \
     && apt-get install -y build-essential \
     && apt-get install -y python \
-    && apt-get install -y exiftran
+    && apt-get install -y exiftran \
+    && apt-get install -y libvips libvips-tools

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ ssl/
 # Cypress output
 cypress/videos
 cypress/screenshots
+
+# Test assets
+test/assets/images/big_image_test.png

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ MONGO_INITIAL_DATABASE=<initial database for MongoDB instance>
 SESSION_SECRET=<session secret goes here>
 GA_TRACKING_ID=<Google Analytics Tracking ID (Universal Analytics)>
 LOGIN_TO_UPLOAD=true  # omit this variable if you don't want to require users to login to upload
+FILE_SIZE_LIMIT=5000000 # omit this variable if you want the default file size limit of 500 MB
 
 EVALUATION_MODE=true # omit this variable to diable automatic removal of images
 EXPIRE_AFTER_SECONDS=300 # set this to set time for the images to be stored in database in evaluation mode (default is 300 if unspecified)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,6 +11,7 @@ services:
         command: bash -c "npm test $TEST_FILE"
         environment:
             - NODE_ENV=test
+            - FILE_SIZE_LIMIT=5000000
 
 volumes:
     node_modules:

--- a/lib/database-ops.js
+++ b/lib/database-ops.js
@@ -58,7 +58,19 @@ const insertImageIntoDatabase = function (imageEntry, callback) {
         imageEntry.temp = process.env.EVALUATION_MODE === "true" ? true : false;
         imageEntryCollection.insertOne(imageEntry, function (err, result) {
             if (err) {
-                logger.error("There was an error inserting image entry into the database.");
+                logger.error("There was an error inserting image entry into the database.", err);
+                if (err.code === "ERR_OUT_OF_RANGE" || err.code === 10334 || err.message.includes("too large")) {
+                    /*
+                    TODO: Handle the following cases:
+                    - Image is larger than 16 MB
+                    - Image is smaller than 16 MB but the total size of the enclosing BSON is larger than 16 MB
+                    https://stackoverflow.com/a/67571711
+                    https://www.mongodb.com/docs/manual/reference/limits/#std-label-limit-bson-document-size
+                    */
+                    logger.warn(
+                        "Detected an error message that indicates the BSON document limit has been reached. TODO incorporate GridFS or upload large image files elsewhere. https://stackoverflow.com/a/67571711"
+                    );
+                }
                 callback(
                     {
                         status: "error",

--- a/lib/route/upload/index.js
+++ b/lib/route/upload/index.js
@@ -12,8 +12,10 @@ const multer = require("multer");
 
 const router = express.Router();
 
+const DEFAULT_FILE_SIZE_LIMIT = 500000000;
+
 const upload = multer({
-    limits: { fileSize: 500000000 },
+    limits: { fileSize: parseInt(process.env.FILE_SIZE_LIMIT) || DEFAULT_FILE_SIZE_LIMIT },
 });
 
 router.post("/", format("json"), injectUser, uploadLimiter, function (req, res, next) {
@@ -44,6 +46,13 @@ router.post("/", format("json"), injectUser, uploadLimiter, function (req, res, 
 
     uploadFunc(req, res, function (err) {
         if (err) {
+            if (err.code === "LIMIT_FILE_SIZE") {
+                return sendError(err, next, {
+                    message: "Image is too large. Please try again with a smaller image.",
+                    errorID: "imageTooLarge",
+                    statusCode: 413,
+                });
+            }
             return sendError(err, next);
         }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -60,7 +60,7 @@ module.exports.runServer = function (portNumber, callback) {
     httpServer = app.listen(portNumber, () => {
         logger.info("Server running at http://localhost:" + portNumber + "/");
     });
-    // HTTPS server is used in dev only, heroku provides SSL in production
+    // HTTPS server is used in dev only, Fly.io provides SSL in production
     if (process.env.NODE_ENV === "development" && process.env.USE_DEV_HTTPS === "true") {
         httpsServer = https
             .createServer(

--- a/package.json
+++ b/package.json
@@ -77,5 +77,10 @@
     "hooks": {
       "pre-commit": "pretty-quick --staged"
     }
+  },
+  "config": {
+    "mongodbMemoryServer": {
+      "version": "4.4.6"
+    }
   }
 }

--- a/test/scripts/generate_large_image.sh
+++ b/test/scripts/generate_large_image.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+vips gaussnoise ./test/assets/images/big_image_test.png 5000 5000


### PR DESCRIPTION
If omitted, the file size limit will default to 500 MB (which, up until now, was the hardcoded file limit)

Also remove comment reference to Heroku that I forgot to take out when migrating to Fly.io.

si-test-deps image was updated to include libvips, which is only used to create the large image for the large image test when running in CI.