### PR TITLE
Highlight error fields in change password form

### DIFF
--- a/cypress/e2e/6-settings/change-password.cy.js
+++ b/cypress/e2e/6-settings/change-password.cy.js
@@ -17,12 +17,33 @@ describe("change password", () => {
         cy.get("input[name='oldPassword']").type(password);
         cy.get("input[name='newPassword']").type(newPassword);
         cy.get("input[name='newPasswordConfirm']").type(newPassword);
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+
         cy.get(".submit-button").click();
 
         cy.wait("@changePassword").its("response.statusCode").should("eq", 200);
 
         // TODO assert using an success code or some other form of success ID instead
         cy.assertSuccessMessageContains("Password changed");
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
 
         cy.logout();
         cy.login(username, newPassword).its("status").should("eq", 200);
@@ -32,12 +53,33 @@ describe("change password", () => {
 
         cy.get("input[name='newPassword']").type(newPassword);
         cy.get("input[name='newPasswordConfirm']").type(newPassword);
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+
         cy.get(".submit-button").click();
 
         cy.wait("@changePassword").its("response.statusCode").should("eq", 422);
 
         // TODO assert using an error code or some other form of error ID instead
         cy.assertErrorMessageContains("Could not change password. Missing old password.");
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
 
         cy.logout();
         cy.login(username, password).its("status").should("eq", 200);
@@ -48,12 +90,33 @@ describe("change password", () => {
         cy.get("input[name='oldPassword']").type("wrong");
         cy.get("input[name='newPassword']").type(newPassword);
         cy.get("input[name='newPasswordConfirm']").type(newPassword);
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+
         cy.get(".submit-button").click();
 
         cy.wait("@changePassword").its("response.statusCode").should("eq", 400);
 
         // TODO assert using an error code or some other form of error ID instead
         cy.assertErrorMessageContains("Could not change password. Old password is not correct.");
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
 
         cy.logout();
         cy.login(username, password).its("status").should("eq", 200);
@@ -63,12 +126,33 @@ describe("change password", () => {
 
         cy.get("input[name='oldPassword']").type(password);
         cy.get("input[name='newPasswordConfirm']").type(newPassword);
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+
         cy.get(".submit-button").click();
 
         cy.wait("@changePassword").its("response.statusCode").should("eq", 422);
 
         // TODO assert using an error code or some other form of error ID instead
         cy.assertErrorMessageContains("Could not change password. Missing new password.");
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
 
         cy.logout();
         cy.login(username, password).its("status").should("eq", 200);
@@ -78,12 +162,33 @@ describe("change password", () => {
 
         cy.get("input[name='oldPassword']").type(password);
         cy.get("input[name='newPassword']").type(newPassword);
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+
         cy.get(".submit-button").click();
 
         cy.wait("@changePassword").its("response.statusCode").should("eq", 422);
 
         // TODO assert using an error code or some other form of error ID instead
         cy.assertErrorMessageContains("Could not change password. Missing new password confirmation.");
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return Array.from(el[0].classList).includes("input-field-error");
+        });
 
         cy.logout();
         cy.login(username, password).its("status").should("eq", 200);
@@ -94,12 +199,74 @@ describe("change password", () => {
         cy.get("input[name='oldPassword']").type(password);
         cy.get("input[name='newPassword']").type(newPassword);
         cy.get("input[name='newPasswordConfirm']").type("wrong");
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+
         cy.get(".submit-button").click();
 
         cy.wait("@changePassword").its("response.statusCode").should("eq", 400);
 
         // TODO assert using an error code or some other form of error ID instead
         cy.assertErrorMessageContains("Could not change password. Passwords don't match.");
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return Array.from(el[0].classList).includes("input-field-error");
+        });
+
+        cy.logout();
+        cy.login(username, password).its("status").should("eq", 200);
+    });
+    it("should not change user password if new password is not strong enough", () => {
+        cy.intercept("POST", "/settings/change_password").as("changePassword");
+
+        const newWeakPassword = "weak";
+
+        cy.get("input[name='oldPassword']").type(password);
+        cy.get("input[name='newPassword']").type(newWeakPassword);
+        cy.get("input[name='newPasswordConfirm']").type(newWeakPassword);
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+
+        cy.get(".submit-button").click();
+
+        cy.wait("@changePassword").then((interception) => {
+            const response = interception.response;
+
+            expect(response.statusCode).to.eql(400);
+            expect(response.body.errorID).to.eql("passwordNotStrong");
+        });
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return Array.from(el[0].classList).includes("input-field-error");
+        });
 
         cy.logout();
         cy.login(username, password).its("status").should("eq", 200);
@@ -144,5 +311,78 @@ describe("change password", () => {
         cy.logout();
         cy.login(username, password).its("status").should("eq", 401);
         cy.login(username, newPassword).its("status").should("eq", 401);
+    });
+    it("should clear notifications and input fields when attempting to change password multiple times", () => {
+        cy.intercept("POST", "/settings/change_password").as("changePassword");
+
+        cy.get("input[name='oldPassword']").type(password);
+        cy.get("input[name='newPassword']").type(newPassword);
+        cy.get("input[name='newPasswordConfirm']").type("wrong");
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+
+        cy.get(".submit-button").click();
+
+        cy.wait("@changePassword").its("response.statusCode").should("eq", 400);
+
+        cy.assertErrorMessageContains("Could not change password. Passwords don't match.");
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return Array.from(el[0].classList).includes("input-field-error");
+        });
+
+        cy.get(".submit-button").click();
+
+        cy.wait("@changePassword").its("response.statusCode").should("eq", 400);
+
+        cy.assertErrorMessageContains("Could not change password. Passwords don't match.");
+        cy.assertErrorMessageNotContains(
+            "Could not change password. Passwords don't match.Could not change password. Passwords don't match."
+        );
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return Array.from(el[0].classList).includes("input-field-error");
+        });
+
+        cy.get("input[name='newPasswordConfirm']").clear().type(newPassword);
+
+        cy.get(".submit-button").click();
+
+        cy.wait("@changePassword").its("response.statusCode").should("eq", 200);
+
+        cy.assertSuccessMessageContains("Password changed.");
+        cy.assertSuccessMessageNotContains(
+            "Could not change password. Passwords don't match.Could not change password. Passwords don't match.Password changed."
+        );
+
+        cy.get("input[name='oldPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPassword']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
+        cy.get("input[name='newPasswordConfirm']").should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("input-field-error");
+        });
     });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -45,6 +45,15 @@ Cypress.Commands.add("assertErrorMessageContainsMulti", (messages) => {
     });
 });
 
+Cypress.Commands.add("assertErrorMessageNotContains", (message) => {
+    cy.get("#notification-overlay-container")
+        .should("be.visible")
+        .should("satisfy", (el) => {
+            return Array.from(el[0].classList).includes("error");
+        })
+        .should("not.contain.text", message);
+});
+
 Cypress.Commands.add("assertSuccessMessageContains", (message) => {
     cy.get("#notification-overlay-container")
         .should("be.visible")
@@ -64,6 +73,15 @@ Cypress.Commands.add("assertSuccessMessageContainsMulti", (messages) => {
     messages.forEach((message) => {
         chain.should("contain.text", message);
     });
+});
+
+Cypress.Commands.add("assertSuccessMessageNotContains", (message) => {
+    cy.get("#notification-overlay-container")
+        .should("be.visible")
+        .should("satisfy", (el) => {
+            return !Array.from(el[0].classList).includes("error");
+        })
+        .should("not.contain.text", message);
 });
 
 Cypress.Commands.add("deleteUser", (username) => {

--- a/lib/route/register/index.js
+++ b/lib/route/register/index.js
@@ -103,7 +103,7 @@ router.post("/", format("json"), limiter, function (req, res, next) {
         return sendError(next, {
             statusCode: 400,
             message: passwordStrengthResult.errors.join("\n"),
-            errorID: "weakPassword",
+            errorID: "passwordNotStrong",
             fields: ["password", "passwordConfirm"],
         });
     }

--- a/lib/route/settings/index.js
+++ b/lib/route/settings/index.js
@@ -112,7 +112,7 @@ router.post("/change_password", format("json"), requireUser, limiter, function (
             return sendError(next, {
                 errorID: "passwordNotStrong",
                 message: passwordStrengthResult.errors.join("\n"),
-                field: "newPassword",
+                fields: ["newPassword", "newPasswordConfirm"],
                 statusCode: 400,
             });
         }

--- a/test/integ/user_register_integ_test.js
+++ b/test/integ/user_register_integ_test.js
@@ -46,13 +46,7 @@ describe("integ", () => {
         it("should not be able to register user if password confirmation is incorrect", () => {
             return assertUserDoesNotExist(TEST_USER)
                 .then(() => {
-                    return registerUser(
-                        agent,
-                        TEST_USER,
-                        TEST_PASSWORD,
-                        "wrong-password",
-                        TEST_EMAIL
-                    );
+                    return registerUser(agent, TEST_USER, TEST_PASSWORD, "wrong-password", TEST_EMAIL);
                 })
                 .then((res) => {
                     assert.equal(res.status, 400);
@@ -78,13 +72,7 @@ describe("integ", () => {
                     return assertUserEmail(TEST_EMAIL);
                 })
                 .then(() => {
-                    return registerUser(
-                        agent,
-                        TEST_USER,
-                        TEST_PASSWORD,
-                        TEST_PASSWORD,
-                        "not.test.user@example.com"
-                    );
+                    return registerUser(agent, TEST_USER, TEST_PASSWORD, TEST_PASSWORD, "not.test.user@example.com");
                 })
                 .then((res) => {
                     assert.equal(res.status, 400);
@@ -149,13 +137,7 @@ describe("integ", () => {
         it("should not be able to register user if email is invalid", () => {
             return assertUserDoesNotExist(TEST_USER)
                 .then(() => {
-                    return registerUser(
-                        agent,
-                        TEST_USER,
-                        TEST_PASSWORD,
-                        TEST_PASSWORD,
-                        "invalidemail"
-                    );
+                    return registerUser(agent, TEST_USER, TEST_PASSWORD, TEST_PASSWORD, "invalidemail");
                 })
                 .then((res) => {
                     assert.equal(res.status, 400);
@@ -166,17 +148,10 @@ describe("integ", () => {
         });
 
         it("should not be able to register user if username is too long", () => {
-            const longUsername =
-                "reallyreallyreallyreallyreallyreallyreallyreallyreallyreallylongusername";
+            const longUsername = "reallyreallyreallyreallyreallyreallyreallyreallyreallyreallylongusername";
             return assertUserDoesNotExist(longUsername)
                 .then(() => {
-                    return registerUser(
-                        agent,
-                        longUsername,
-                        TEST_PASSWORD,
-                        TEST_PASSWORD,
-                        TEST_EMAIL
-                    );
+                    return registerUser(agent, longUsername, TEST_PASSWORD, TEST_PASSWORD, TEST_EMAIL);
                 })
                 .then((res) => {
                     assert.equal(res.status, 400);
@@ -194,7 +169,7 @@ describe("integ", () => {
                 .then((res) => {
                     assert.equal(res.status, 400);
                     assert.equal(res.body.status, "error");
-                    assert.equal(res.body.errorID, "weakPassword");
+                    assert.equal(res.body.errorID, "passwordNotStrong");
                     return assertUserDoesNotExist(TEST_USER);
                 });
         });
@@ -252,10 +227,7 @@ describe("integ", () => {
         });
 
         it("should fail if database cannot add user", () => {
-            const addUserStub = stub(databaseOps, "addUser").callsArgWith(
-                1,
-                new Error("Database error")
-            );
+            const addUserStub = stub(databaseOps, "addUser").callsArgWith(1, new Error("Database error"));
             return assertUserDoesNotExist(TEST_USER)
                 .then(() => {
                     return registerUser(agent, TEST_USER, TEST_PASSWORD, TEST_PASSWORD, TEST_EMAIL);

--- a/views/settings-view.ejs
+++ b/views/settings-view.ejs
@@ -12,7 +12,7 @@
         integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=" crossorigin="anonymous"></script>
     <script src="/assets/js/user.bundle.js"></script>
     <script>
-        var onPasswordResetSubmitted = function() {
+        var onPasswordResetSubmitted = function(form) {
             let jsonObj;
             try {
                 jsonObj = JSON.parse(this.responseText);
@@ -20,13 +20,44 @@
                 handleResponseFailure(this.status);
                 return console.error("[onPasswordResetSubmitted]", "Error occurred when parsing response", err);
             }
+
+            // Clear out error style from all input fields.
+            for (const inputFieldIndex in form.elements) {
+                if (form.elements[inputFieldIndex].classList) {
+                    form.elements[inputFieldIndex].classList.remove("input-field-error");
+                }
+            }
+            
             if (this.status !== 200) {
                 showNotification(jsonObj.message, {
-                    error: true
+                    error: true,
+                    clear: true,
                 });
+
+                // If there's an additional info specified with this error,
+                // attempt to grab the field (or fields) property, associate with name
+                // of corresponding input field, and append error style to it.
+                if (jsonObj.additionalInfo) {
+                    var fieldObj = jsonObj.additionalInfo.field || jsonObj.additionalInfo.fields;
+                    var fieldElems;
+                    if (typeof fieldObj === "object") {
+                        fieldElems = fieldObj.reduce(function (obj, field) {
+                            obj.push(form.elements[field]);
+                            return obj;
+                        }, []);
+                    } else {
+                        fieldElems = [form.elements[fieldObj]];
+                    }
+                    fieldElems.forEach(function (fieldElem) {
+                        if (fieldElem) {
+                            fieldElem.classList.add("input-field-error");
+                        }
+                    });
+                }
             } else {
                 showNotification(jsonObj.message, {
-                    error: false
+                    error: false,
+                    clear: true,
                 });
             }
         };
@@ -36,7 +67,9 @@
             const action = form.attr("action");
             const req = new XMLHttpRequest();
 
-            req.onload = onPasswordResetSubmitted;
+            req.onload = function () {
+                onPasswordResetSubmitted.bind(this)(form[0]);
+            };
             req.open("post", action);
             req.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
             req.send(form.serialize());


### PR DESCRIPTION
Other Changes:
- Password strength failure in change password will now report the newPasswordConfirm field in addition to the newPassword field in its response
- Notifications in change password page will now clear before a new notification is displayed
- Have password strength errors share the same error ID